### PR TITLE
Use JSX not Javascript as md code hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm i style-bubble
 yarn add style-bubble
 ```
 
-```javascript
+```jsx
 import React from 'react';
 import StyleBubble from 'style-bubble';
 


### PR DESCRIPTION
The readme had javascript as the hint for the code block, so I changed it to jsx so that it would display more prettily.